### PR TITLE
Bug on test 8

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -411,6 +411,7 @@ printf "${BLUE}# $num: %-69s  []${NC}" "$description"
 if should_execute ${num##0} ${test_suites[@]}
 then
 	PATH=$PWD/assets:$PATH pipex_test $PROJECT_DIRECTORY/pipex "assets/deepthought.txt" "grep Now" "exit 5" "outs/test-$num.txt" > outs/test-$num-tty.txt 2>&1
+	status_code=$?
 	if [ $status_code -lt 128 ] # 128 is the last code that bash uses before signals
 	then
 		TESTS_OK=$(($TESTS_OK + 1))


### PR DESCRIPTION
On all tests, after the execution of the pipex_test, the status code is stored on the variable "status_code".
However, on the 8th test, this was not the case.

With this simple request, the problem should be fixed.